### PR TITLE
configs.go : Allow bison, flex

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -76,6 +76,7 @@ func GetConfig(name string) PathConfig {
 var Configuration = map[string]PathConfig{
 	"bash":     Allowed,
 	"bc":       Allowed,
+	"bison":    Log,
 	"bzip2":    Allowed,
 	"date":     Allowed,
 	"dd":       Allowed,
@@ -84,6 +85,7 @@ var Configuration = map[string]PathConfig{
 	"egrep":    Allowed,
 	"expr":     Allowed,
 	"find":     Allowed,
+	"flex":     Log,
 	"flock":    Allowed,
 	"fuser":    Allowed,
 	"getopt":   Allowed,


### PR DESCRIPTION
This is actually needed for some devices to build their kernel inline
and being able to assemble them as a bootimage such as Sony devices.
Thanks ElGoog, we hate it.