### PR TITLE
Add python3.9 to allowed paths

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -102,6 +102,7 @@ var Configuration = map[string]PathConfig{
 	"python3.6": Allowed,
 	"python3.7": Allowed,
 	"python3.8": Allowed,
+	"python3.9": Allowed,
 	"repo":    Allowed,
 	"rsync":   Allowed,
 	"sh":      Allowed,


### PR DESCRIPTION
*fixes building changelog on more bleeding edge distros like arch/manjaro/sid