### PR TITLE
Add python3.10 to allowed paths

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -101,6 +101,7 @@ var Configuration = map[string]PathConfig{
 	"python3.7": Allowed,
 	"python3.8": Allowed,
 	"python3.9": Allowed,
+	"python3.10": Allowed,
 	"repo":    Allowed,
 	"rsync":   Allowed,
 	"sh":      Allowed,


### PR DESCRIPTION
*fixes building changelog on bleeding edge distros like arch/manjaro/sid