### PR TITLE
Expose Clang wrapper's dump usage stats option

### DIFF
--- a/ui/build/dumpvars.go
+++ b/ui/build/dumpvars.go
@@ -210,6 +210,9 @@ func runMakeProductConfig(ctx Context, config Config) {
 		"CCACHE_SLOPPINESS",
 		"CCACHE_BASEDIR",
 		"CCACHE_CPP2",
+
+		// LLVM compiler wrapper options
+		"TOOLCHAIN_RUSAGE_OUTPUT",
 	}
 
 	allVars := append(append([]string{

--- a/ui/build/ninja.go
+++ b/ui/build/ninja.go
@@ -167,6 +167,9 @@ func runNinjaForBuild(ctx Context, config Config) {
 			"CCACHE_BASEDIR",
 			"CCACHE_CPP2",
 			"CCACHE_DIR",
+
+			// LLVM compiler wrapper options
+			"TOOLCHAIN_RUSAGE_OUTPUT",
 		}, config.BuildBrokenNinjaUsesEnvVars()...)...)
 	}
 


### PR DESCRIPTION
This allows us to track how much time is spent in Clang.

Test: TOOLCHAIN_RUSAGE_OUTPUT=/tmp/rusage.txt m
Change-Id: Ib2961904f363bc59bd9d928bb055a96740cb9f17