### PR TITLE
check_boot_jars: add com.oplus.os to whitelist

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -263,6 +263,9 @@ org\.lineageos\.platform\.internal
 com\.nvidia
 com\.nvidia\..*
 
+# OPlus
+com.oplus.os
+
 # QC adds
 com.qualcomm.qti
 com.quicinc.tcmiface


### PR DESCRIPTION
Fixes error:
out/soong/.intermediates/frameworks/base/framework-minus-apex/android_common/aligned/framework-minus-apex.jar contains class file com.oplus.os.LinearmotorVibrator, whose package name "com.oplus.os" is empty or not in the allow list build/soong/scripts/check_boot_jars/package_allowed_list.txt of packages allowed on the bootclasspath.
Signed-off-by: Ionut Gherman <ghermanionut96@gmail.com>