### PR TITLE
soong: Disable sandbox

### DIFF
--- a/ui/build/sandbox_linux.go
+++ b/ui/build/sandbox_linux.go
@@ -34,7 +34,7 @@ type Sandbox struct {
 var (
 	noSandbox    = Sandbox{}
 	basicSandbox = Sandbox{
-		Enabled: true,
+		Enabled: false,
 	}
 
 	dumpvarsSandbox = basicSandbox


### PR DESCRIPTION
AOSP compiler seems to ignore it anyhow. Disabling it silences the following warning:

**Build sandboxing disabled due to nsjail error.**