### PR TITLE
Avoid "custom firmware" detection [2/2]

### DIFF
--- a/scripts/gen_build_prop.py
+++ b/scripts/gen_build_prop.py
@@ -347,6 +347,8 @@ def append_additional_system_props(args):
     # Target is secure in user builds.
     props.append("ro.secure=1")
     props.append("security.perf_harden=1")
+    # at least one app (Revolut) refuses to work with yellow verifiedbootstate
+    props.append("ro.appcompat_override.ro.boot.verifiedbootstate=green")
 
     if config["BuildVariant"] == "user":
       # Disable debugging in plain user builds.


### PR DESCRIPTION
[Corresponding patches in android_vendor_crdroid as well]

Even if device is appearing as certified in Play Store, some of the "unlocked bootloader/custom firmware" detection SDKs are looking for extra 'not-Google' tells like timestamps not being explicitly in UTC or build user/host props not matching Pixel patterns.

Continue trying to look "normal" so we pass by default.

References:
https://grapheneos.social/@GrapheneOS/113869639765611071
https://review.lineageos.org/q/topic:%2222.2-hide-builder%22
https://dumps.tadiphone.dev/dumps/google/bluejay/-/blob/bluejay-user-15-BP1A.250405.005-13150826-release-keys/system/system/build.prop

Tests:
Before - Attempting to login/signup in Revolut Business app ends in "Custom firmware not supported" screen (even with fresh "Device is certified" status in Play Store)
After - Success getting to login & signup screens after flash/reboot.